### PR TITLE
Use a symbolic link when linking php to intellij

### DIFF
--- a/lib/vagrant-phpstorm-tunnel/configurator.rb
+++ b/lib/vagrant-phpstorm-tunnel/configurator.rb
@@ -19,7 +19,7 @@ module VagrantPhpstormTunnel
       destination_path = File.join(@home_path, 'php')
       source_path = File.expand_path('../../../data/php', __FILE__)
 
-      File.link(source_path, destination_path)
+      File.symlink(source_path, destination_path)
       File.chmod(0755, destination_path)
     end
 


### PR DESCRIPTION
Resolves #22 

I've tested this in my configuration (Linux host and guest) and everything seems to work as intended, but I am not sure if this would break anything with a Windows host and/or guest.